### PR TITLE
Correct the mid/treble segments' average calc.

### DIFF
--- a/Lesson06-Visualizer-Preferences/T06.01-Exercise-SetupTheActivity/app/src/main/java/android/example/com/visualizerpreferences/AudioVisuals/VisualizerView.java
+++ b/Lesson06-Visualizer-Preferences/T06.01-Exercise-SetupTheActivity/app/src/main/java/android/example/com/visualizerpreferences/AudioVisuals/VisualizerView.java
@@ -200,14 +200,14 @@ public class VisualizerView extends View {
 
         // Calculate average for mid segment
         float midTotal = 0;
-        for (int i = (int) (bytes.length * BASS_SEGMENT_SIZE); i < bytes.length * MID_SEGMENT_SIZE; i++) {
+        for (int i = (int) (bytes.length * BASS_SEGMENT_SIZE); i < bytes.length * (BASS_SEGMENT_SIZE + MID_SEGMENT_SIZE); i++) {
             midTotal += Math.abs(bytes[i]);
         }
         mid = midTotal / (bytes.length * MID_SEGMENT_SIZE);
 
-        // Calculate average for terble segment
+        // Calculate average for treble segment
         float trebleTotal = 0;
-        for (int i = (int) (bytes.length * MID_SEGMENT_SIZE); i < bytes.length; i++) {
+        for (int i = (int) (bytes.length * (BASS_SEGMENT_SIZE + MID_SEGMENT_SIZE)); i < bytes.length; i++) {
             trebleTotal += Math.abs(bytes[i]);
         }
         treble = trebleTotal / (bytes.length * TREBLE_SEGMENT_SIZE);


### PR DESCRIPTION
The existed algorithm used different sum in iteration and division method for mid and treble segment.
For example, as per mid segment.
Iteration sum: bytes.length * (MID_SEGMENT_SIZE - BASS_SEGMENT_SIZE ) , which is 20% of the bytes size.
Division's divisor: bytes.length * MID_SEGMENT_SIZE, which is 30% of the bytes size.
So we did not get the real average actually yet.